### PR TITLE
Add ability to sync Google Calendar ACL with the member roster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -69,7 +69,19 @@ The following examples operate on users.
 
 Fetch users from the SCMA website and converts them to YAML.
 
- scma-gcal-sync -u <scma-username> -p <scma-password> -d users -o yaml > users.yml
+ scma-gcal-sync -d users -u <scma-username> -p <scma-password> -o yaml > users.yml
+
+==== YAML to GCal
+
+Read users from a YAML file and sync them to the Access Control List (ACL) for Google Calendar.
+
+ scma-gcal-sync -d users -i yaml --ifile users.yml
+
+==== Web to GCal
+
+Fetch users from the SCMA website and sync them to the Access Control List (ACL) for Google Calendar.
+
+ scma-gcal-sync -d users -u <scma-username> -p <scma-password>
 
 == Limitations
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,18 @@ async fn process_users(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     match args.output {
-        OutputType::GCal => todo!(),
+        OutputType::GCal => {
+            let emails: Vec<&str> = users.iter().map(|user| user.email.as_ref()).collect();
+
+            GCal::new(
+                &args.calendar,
+                &args.client_secret_json_path,
+                &args.oauth_token_json_path,
+            )
+            .await?
+            .acl_sync(&emails)
+            .await?;
+        }
         OutputType::Yaml => {
             info!(output=?args.output_file, "Writing users");
             match args.output_file {

--- a/src/output/gcal.rs
+++ b/src/output/gcal.rs
@@ -151,7 +151,7 @@ impl GCal {
         Ok(())
     }
 
-    /// Fetches entire ACL using one or more requests for pagination
+    /// Fetches entire ACL by fetching all pages of the ACL
     async fn acl_list(
         &self,
     ) -> Result<Vec<api::AclRule>, Box<dyn std::error::Error>> {

--- a/src/output/gcal.rs
+++ b/src/output/gcal.rs
@@ -63,8 +63,8 @@ impl GCal {
                     ..Default::default()
                 };
                 let (rsp, calendar) = hub.calendars().insert(req).add_scope(SCOPE).doit().await?;
-                trace!(?rsp);
-                debug!(?calendar);
+                trace!(?rsp, "calendars.insert");
+                debug!(?calendar, "calendars.insert");
 
                 let calendar_id = calendar.id.as_ref().unwrap().clone();
                 info!(%calendar_name, %calendar_id, "Inserted new calendar");
@@ -169,8 +169,8 @@ impl GCal {
             .send_notifications(SEND_NOTIFICATIONS_ACL_INSERT)
             .doit()
             .await?;
-        trace!(?rsp);
-        debug!(?rule);
+        trace!(?rsp, "acl.insert");
+        debug!(?rule, "acl.insert");
 
         Ok(())
     }
@@ -185,7 +185,7 @@ impl GCal {
             .delete(&self.calendar_id, &rule_id)
             .doit()
             .await?;
-        trace!(?rsp);
+        trace!(?rsp, "acl.delete");
 
         Ok(())
     }
@@ -219,8 +219,8 @@ impl GCal {
             None => call,
         };
         let (rsp, acl) = call.doit().await?;
-        trace!(?rsp);
-        debug!(?acl);
+        trace!(?rsp, "acl.list");
+        debug!(?acl, "acl.list");
 
         Ok((acl.items.unwrap(), acl.next_page_token))
     }
@@ -275,6 +275,14 @@ impl GCal {
             .doit()
             .await;
         match result {
+            Ok(rsp) => {
+                let (rsp, g_event) = rsp;
+                trace!(?rsp, "events.patch");
+                debug!(?g_event, "events.patch");
+
+                let link = g_event.html_link.as_ref().unwrap();
+                info!(%event.id, %event, %link, "Updated");
+            }
             Err(_) => {
                 let (rsp, g_event) = self
                     .hub
@@ -283,19 +291,11 @@ impl GCal {
                     .add_scope(SCOPE)
                     .doit()
                     .await?;
-                trace!(?rsp);
-                debug!(?g_event);
+                trace!(?rsp, "events.insert");
+                debug!(?g_event, "events.insert");
 
                 let link = g_event.html_link.as_ref().unwrap();
                 info!(%event.id, %event, %link, "Inserted");
-            }
-            Ok(rsp) => {
-                let (rsp, g_event) = rsp;
-                trace!(?rsp);
-                debug!(?g_event);
-
-                let link = g_event.html_link.as_ref().unwrap();
-                info!(%event.id, %event, %link, "Updated");
             }
         }
 


### PR DESCRIPTION
This PR adds the ability to sync the Google Calendar ACL (Access Control List) with the SCMA member roster thereby giving all SCMA members read access to the Google Calendar.

Closes #1 