### PR TITLE
v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "scma-gcal-sync"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scma-gcal-sync"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["Rob Donnelly <rfdonnelly@gmail.com>"]
 description = "Synchronizes Southern California Mountaineers Association (SCMA) calendar events to Google Calendar"


### PR DESCRIPTION
This release adds the ability to sync users to both the Google Calendar ACL (Access Control List) and Google Contacts.  The ACL sync feature automates calendar access management.  It gives all SCMA members read access to the calendar and removes access for any non-SCMA members (i.e. those that are no longer SCMA members).

## Added

* Added auto create the named calendar if it doesn't exist
* Added `--dry-run` option
* Added Google Calendar ACL sync
* Added Google Contacts sync

## Changed

* Normalize SCMA phone numbers using "+1##########" format.  Previously used the whatever format was given which varied from member to member.
*  Normalize SCMA emails to use all lowercase. Previously used whatever case was given which varied from member to member.