### PR TITLE
Add service account authentication

### DIFF
--- a/src/output/gauth.rs
+++ b/src/output/gauth.rs
@@ -3,6 +3,7 @@ use hyper_rustls::HttpsConnector;
 use tracing::info;
 use yup_oauth2::{
     authenticator::Authenticator, InstalledFlowAuthenticator, InstalledFlowReturnMethod,
+    ServiceAccountAuthenticator,
 };
 
 pub struct GAuth {
@@ -10,18 +11,29 @@ pub struct GAuth {
 }
 
 impl GAuth {
-    pub async fn new(
+    pub async fn with_oauth(
         client_secret_json_path: &str,
         oauth_token_json_path: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let secret = yup_oauth2::read_application_secret(client_secret_json_path).await?;
 
-        info!(oauth_client_id=?secret.client_id, "Authenticating");
+        info!(client_id=?secret.client_id, "Authenticating using OAuth");
         let auth =
             InstalledFlowAuthenticator::builder(secret, InstalledFlowReturnMethod::HTTPRedirect)
                 .persist_tokens_to_disk(oauth_token_json_path)
                 .build()
                 .await?;
+
+        Ok(Self { auth })
+    }
+
+    pub async fn with_service_account(
+        client_secret_json_path: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let secret = yup_oauth2::read_service_account_key(client_secret_json_path).await?;
+
+        info!(client_id=?secret.client_id, client_email=?secret.client_email, "Authenticating using service account");
+        let auth = ServiceAccountAuthenticator::builder(secret).build().await?;
 
         Ok(Self { auth })
     }


### PR DESCRIPTION
This PR adds the `--auth-type (oauth|service-account|infer)` option that defaults to `infer`.  The possible values are:

* `oauth` -- Use OAuth user account authentication
* `service-account` -- Use service account authentication
* `infer` -- Infer the auth-type based on the service.
  * Google Calendar infers `service-account`
  * Google People infers `oauth`.

BREAKING CHANGE: This changes the default authentication type for the Google Calendar API from OAuth to service account authentication.

Closes #25 