### PR TITLE
Add "last updated" field to users

### DIFF
--- a/src/input/snapshots/scma_gcal_sync__input__web__test__parse_users.snap
+++ b/src/input/snapshots/scma_gcal_sync__input__web__test__parse_users.snap
@@ -1,8 +1,7 @@
 ---
 source: src/input/web.rs
-assertion_line: 460
+assertion_line: 480
 expression: users
-
 ---
 - name: John Doe
   member_status: RM
@@ -14,6 +13,7 @@ expression: users
   zipcode: "55555"
   phone: "+15555555555"
   email: johndoe@gmail.com
+  timestamp: ~
 - name: Jane Doe
   member_status: HM
   trip_leader_status: S2
@@ -24,6 +24,7 @@ expression: users
   zipcode: "55555"
   phone: "+11234567890"
   email: jane.doe@gmail.com
+  timestamp: ~
 - name: First Last
   member_status: Student
   trip_leader_status: ~
@@ -34,4 +35,5 @@ expression: users
   zipcode: "55553"
   phone: "+15555555554"
   email: first.last@gmail.com
+  timestamp: ~
 

--- a/src/input/web.rs
+++ b/src/input/web.rs
@@ -440,6 +440,7 @@ impl TryFrom<(UserTableRow<'_>, &EmailIdTable)> for User {
         let undefined = "UNDEFINED".to_string();
         let email = emails.get(email_id).unwrap_or(&undefined);
         let email = normalize_email(email);
+        let timestamp = Some(Utc::now());
 
         let user = User {
             name,
@@ -452,6 +453,7 @@ impl TryFrom<(UserTableRow<'_>, &EmailIdTable)> for User {
             zipcode,
             phone,
             email,
+            timestamp,
         };
 
         Ok(user)
@@ -513,7 +515,9 @@ mod test {
     fn parse_users() {
         let path = path_to_input("users.html");
         let page = Page::from_file(path).unwrap();
-        let users = Users::try_from(page).unwrap();
+        let users = Users::try_from(page).unwrap().tap_mut(|users| {
+            users.0.iter_mut().for_each(|user| user.timestamp = None);
+        });
         insta::assert_yaml_snapshot!(users);
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -28,6 +28,20 @@ pub struct Event {
     pub timestamp: Option<DateTime<Utc>>,
 }
 
+impl Event {
+    pub fn timestamp(&self) -> String {
+        if let Some(timestamp) = self.timestamp {
+            let pacific = chrono::FixedOffset::west_opt(8 * 60 * 60).unwrap();
+            timestamp
+                .with_timezone(&pacific)
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, false)
+                .to_string()
+        } else {
+            "".to_string()
+        }
+    }
+}
+
 impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ({}/{})", self.title, self.start_date, self.end_date)
@@ -157,6 +171,8 @@ pub struct User {
     pub zipcode: String,
     pub phone: Option<String>,
     pub email: String,
+    /// The date and time the event page was downloaded.
+    pub timestamp: Option<DateTime<Utc>>,
 }
 
 impl User {
@@ -169,5 +185,17 @@ impl User {
             "{}, {}, {} {}",
             self.address, self.city, self.state, self.zipcode
         )
+    }
+
+    pub fn timestamp(&self) -> String {
+        if let Some(timestamp) = self.timestamp {
+            let pacific = chrono::FixedOffset::west_opt(8 * 60 * 60).unwrap();
+            timestamp
+                .with_timezone(&pacific)
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, false)
+                .to_string()
+        } else {
+            "".to_string()
+        }
     }
 }

--- a/src/output/gcal.rs
+++ b/src/output/gcal.rs
@@ -482,9 +482,8 @@ fn event_description(event: &Event) -> Result<String, Box<dyn ::std::error::Erro
         }
     }
 
-    if let Some(timestamp) = event.timestamp {
-        let pacific = chrono::FixedOffset::west_opt(8 * 60 * 60).unwrap();
-        write!(buffer, "\n\nLast synced at {} by <a href='https://github.com/rfdonnelly/scma-gcal-sync'>scma-gcal-sync</a>.", timestamp.with_timezone(&pacific).to_rfc3339_opts(chrono::SecondsFormat::Secs, false))?;
+    if event.timestamp.is_some() {
+        write!(buffer, "\n\nLast synced at {} by <a href='https://github.com/rfdonnelly/scma-gcal-sync'>scma-gcal-sync</a>.", event.timestamp())?;
     }
 
     Ok(buffer)

--- a/src/output/gppl.rs
+++ b/src/output/gppl.rs
@@ -22,6 +22,7 @@ const PERSON_FIELDS_UPDATE: &str = "addresses,phoneNumbers,userDefined";
 const SCMA_MEMBER_STATUS_KEY: &str = "SCMA Member Status";
 const SCMA_TRIP_LEADER_STATUS_KEY: &str = "SCMA Trip Leader Status";
 const SCMA_POSITION_KEY: &str = "SCMA Position";
+const SCMA_LAST_UPDATED_KEY: &str = "SCMA Last Updated";
 
 /// Synchronizes SCMA members with Google Contacts using the algorithm below.
 ///
@@ -557,6 +558,14 @@ fn create_api_trip_leader_status(user: &User) -> api::UserDefined {
     }
 }
 
+fn create_api_last_updated(user: &User) -> api::UserDefined {
+    api::UserDefined {
+        key: Some(SCMA_LAST_UPDATED_KEY.to_string()),
+        value: Some(user.timestamp()),
+        ..Default::default()
+    }
+}
+
 fn create_api_position(user: &User) -> api::UserDefined {
     api::UserDefined {
         key: Some(SCMA_POSITION_KEY.to_string()),
@@ -603,6 +612,7 @@ fn create_api_person(user: &User, group_resource_name: &str) -> api::Person {
     let member_status = create_api_member_status(user);
     let trip_leader_status = create_api_trip_leader_status(user);
     let position = create_api_position(user);
+    let last_updated = create_api_last_updated(user);
 
     api::Person {
         names: Some(vec![name]),
@@ -610,7 +620,12 @@ fn create_api_person(user: &User, group_resource_name: &str) -> api::Person {
         addresses: Some(vec![address]),
         phone_numbers: Some(vec![phone_number]),
         memberships: Some(vec![membership]),
-        user_defined: Some(vec![member_status, trip_leader_status, position]),
+        user_defined: Some(vec![
+            member_status,
+            trip_leader_status,
+            position,
+            last_updated,
+        ]),
         ..Default::default()
     }
 }
@@ -687,6 +702,7 @@ fn person_user_defined_update_or_insert(
             user.trip_leader_status(),
         );
         user_defined.insert(SCMA_POSITION_KEY.to_string(), user.position());
+        user_defined.insert(SCMA_LAST_UPDATED_KEY.to_string(), user.timestamp());
     })
     .into_iter()
     .map(|(k, v)| api::UserDefined {


### PR DESCRIPTION
This PR adds a "last updated" field to people in Google Contacts.  This allows membership status to be inferred.  I.e. if last updated is not current, then contact is very likely no longer a member.